### PR TITLE
Fix initialization of pseudo locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # ilib-loctool-ruby-ilib
+
 Ilib loctool plugin to parse Ruby files looking for strings localized using ilib
+
+## License
+
+This plugin is license under Apache2. See the [LICENSE](./LICENSE)
+file for more details.
+
+## Release Notes
+
+### v1.1.2
+
+- Fix a bug where the pseudo locales were not initialized properly.
+  This fix gets the right set of locales from the project settings to
+  see if any of them are pseudo locales.
+

--- a/RubyFileType.js
+++ b/RubyFileType.js
@@ -43,7 +43,7 @@ var RubyFileType = function(project) {
     this.pseudos = {};
 
     // generate all the pseudo bundles we'll need
-    project.locales && project.locales.forEach(function(locale) {
+    project.settings && project.settings.locales && project.settings.locales.forEach(function(locale) {
         var pseudo = this.API.getPseudoBundle(locale, this, project);
         if (pseudo) {
             this.pseudos[locale] = pseudo;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "node": ">=6.0"
     },
     "dependencies": {
-        "ilib": "^14.1.0",
+        "ilib": "^14.9.0",
         "log4js": "^2.11.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ruby-ilib",
-    "version": "1.1.1",
+    "version": "1.1.2",
     "main": "./RubyFileType.js",
     "description": "A loctool plugin that knows how to process ruby files that use ilib-style resbundles",
     "license": "Apache-2.0",


### PR DESCRIPTION
- Fix a bug where the pseudo locales were not initialized properly. This fix gets the right set of locales from the project settings to see if any of them are pseudo locales.